### PR TITLE
Rename LocatorMixin update method's argument

### DIFF
--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -296,7 +296,7 @@ mixin LocatorMixin {
   /// This is equivalent to what "ProxyProviders" do using `provider`, but
   /// implemented with no dependency on Flutter.
   @protected
-  void update(Locator watch) {}
+  void update(Locator locator) {}
 }
 
 /// Thrown when called [LocatorMixin.locator], but the object was not found.


### PR DESCRIPTION
Rename LocatorMixin update method's argument to `locator` from `watch`.
This is more natural isn't it?