### PR TITLE
added fireImmediately as an arg to addListener

### DIFF
--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -193,19 +193,7 @@ Consider checking `mounted`.
       return true;
     }());
     assert(_debugIsMounted());
-    final _listener = fireImmediately == true
-        ? listener
-        : () {
-            var skipped = false;
-            return (T state) {
-              if (!skipped) {
-                skipped = true;
-                return;
-              }
-              listener(state);
-            };
-          }();
-    final listenerEntry = _ListenerEntry(_listener);
+    final listenerEntry = _ListenerEntry(listener);
     _listeners.add(listenerEntry);
     try {
       assert(_debugSetCanAddListeners(false));

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -209,7 +209,9 @@ Consider checking `mounted`.
     _listeners.add(listenerEntry);
     try {
       assert(_debugSetCanAddListeners(false));
-      _listener(state);
+      if (fireImmediatly) {
+        listener(state);
+      }
     } catch (err, stack) {
       listenerEntry.unlink();
       onError?.call(err, stack);

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -185,7 +185,7 @@ Consider checking `mounted`.
   ///
   /// Adding and removing listeners is O(1).
   RemoveListener addListener(Listener<T> listener,
-      {bool fireImmediately = true}) {
+      {bool fireImmediately = true,}) {
     assert(() {
       if (!_debugCanAddListeners) {
         throw ConcurrentModificationError();

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -170,8 +170,11 @@ Consider checking `mounted`.
 
   /// Subscribes to this object.
   ///
-  /// The [listener] callback will be called immediatly on addition and
+  /// The [listener] callback will be called immediately on addition and
   /// synchronously whenever [state] changes.
+  /// Set [fireImmediately] to false if you want to skip the first,
+  /// immediate execution of the [listener].
+  ///
   ///
   /// To remove this [listener], call the function returned by [addListener]:
   ///
@@ -184,8 +187,10 @@ Consider checking `mounted`.
   /// Listeners cannot add other listeners.
   ///
   /// Adding and removing listeners is O(1).
-  RemoveListener addListener(Listener<T> listener,
-      {bool fireImmediately = true,}) {
+  RemoveListener addListener(
+    Listener<T> listener, {
+    bool fireImmediately = true,
+  }) {
     assert(() {
       if (!_debugCanAddListeners) {
         throw ConcurrentModificationError();
@@ -197,7 +202,7 @@ Consider checking `mounted`.
     _listeners.add(listenerEntry);
     try {
       assert(_debugSetCanAddListeners(false));
-      if (fireImmediatly) {
+      if (fireImmediately) {
         listener(state);
       }
     } catch (err, stack) {

--- a/packages/state_notifier/test/state_notifier_test.dart
+++ b/packages/state_notifier/test/state_notifier_test.dart
@@ -41,6 +41,22 @@ void main() {
     verify(listener(1)).called(1);
     verifyNoMoreInteractions(listener);
   });
+  test(
+      'listener not called immediately on addition if fireImmediately is false',
+      () {
+    final notifier = TestNotifier(0);
+    final listener = Listener();
+
+    notifier.addListener(listener, fireImmediately: false);
+
+    verifyNever(listener(0));
+    verifyNoMoreInteractions(listener);
+
+    notifier.increment();
+
+    verify(listener(1)).called(1);
+    verifyNoMoreInteractions(listener);
+  });
   test('listener is called after the value is updated', () {
     final notifier = TestNotifier(0);
 


### PR DESCRIPTION
sometimes you just don't want to fire immediately. for example you want to persist the state in a listener.