### PR TITLE
allow/deny state change

### DIFF
--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -146,6 +146,9 @@ Consider checking `mounted`.
   @protected
   set state(T value) {
     assert(_debugIsMounted());
+    if (!allowTransition(_state, value)) {
+      return;
+    }
     _state = value;
 
     var didThrow = false;
@@ -219,6 +222,9 @@ Consider checking `mounted`.
       }
     };
   }
+
+  @protected
+  bool allowTransition(T fromState, T toState) => true;
 
   /// Frees all the resources associated to this object.
   ///

--- a/packages/state_notifier/test/state_notifier_test.dart
+++ b/packages/state_notifier/test/state_notifier_test.dart
@@ -87,15 +87,15 @@ void main() {
 
     // ignore: cascade_invocations
     notifier.increment();
-    expect(notifier.debugState, 0);
+    expect(notifier.currentState, 0);
 
     allow = true;
     notifier.increment();
-    expect(notifier.debugState, 1);
+    expect(notifier.currentState, 1);
 
     allow = false;
     notifier.increment();
-    expect(notifier.debugState, 1);
+    expect(notifier.currentState, 1);
   });
   test('listener can be removed using addListener result', () {
     final notifier = TestNotifier(0);


### PR DESCRIPTION
Hi, i just added some code rather than creating an issue.
The idea is to have an easy way to deny a state change, for example where state must be distinct.
You can always override the state setter, but i thought it might be easier to have a seperate callback function.
In addition we can add helper functions like ```stateIsDistinct()```to be used in ```allowTransition```.

Note; there is no documentation etc. I will add more if you like the idea :)