### PR TITLE
Additional note when using LocatorMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ test('increment and saves to local storage', () {
 });
 ```
 
+**Note:** `LocatorMixin` only works on `StateNotifier`, if you try to use it on other classes by `with LocatorMixin` then it will not work.
+
 # Differences with [ValueNotifier]
 
 This is not a one-to-one reimplementation of [ValueNotifier]. It has some


### PR DESCRIPTION
Currently `LocatorMixin` can only work with` StateNotifier` but there are people who still use it with other classes that lead to errors without understanding the reason. so I think it should be noted when using it.