### PR TITLE
Fix flutter_state_notifier compile error

### DIFF
--- a/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
+++ b/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:state_notifier/state_notifier.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' hide Locator;
 
 /// {@template flutter_state_notifier.state_notifier_builder}
 /// Listens to a [StateNotifier] and use it builds a widget tree based on the

--- a/packages/flutter_state_notifier/test/common.dart
+++ b/packages/flutter_state_notifier/test/common.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' hide Locator;
 import 'package:state_notifier/state_notifier.dart';
 
 class TestNotifier extends StateNotifier<int> with LocatorMixin {


### PR DESCRIPTION
As described here, flutter_state_notifier is broken after v0.6.0, so this PR fixes the compile error.

<img width="757" alt="image" src="https://user-images.githubusercontent.com/1255062/88631068-888ca780-d0ec-11ea-9b79-951487dcbf9b.png">


https://pub.dev/packages/flutter_state_notifier/score