### PR TITLE
Added an optional builder condition

### DIFF
--- a/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
+++ b/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
@@ -3,10 +3,12 @@ library flutter_state_notifier;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
-import 'package:provider/single_child_widget.dart';
-import 'package:state_notifier/state_notifier.dart';
 // ignore: undefined_hidden_name
 import 'package:provider/provider.dart' hide Locator;
+import 'package:provider/single_child_widget.dart';
+import 'package:state_notifier/state_notifier.dart';
+
+typedef BuildCondition<T> = bool Function(T state);
 
 /// {@template flutter_state_notifier.state_notifier_builder}
 /// Listens to a [StateNotifier] and use it builds a widget tree based on the
@@ -18,6 +20,7 @@ class StateNotifierBuilder<T> extends StatefulWidget {
   /// {@macro flutter_state_notifier.state_notifier_builder}
   const StateNotifierBuilder({
     Key key,
+    this.buildWhen,
     @required this.builder,
     @required this.stateNotifier,
     this.child,
@@ -27,6 +30,12 @@ class StateNotifierBuilder<T> extends StatefulWidget {
   ///
   /// Cannot be `null`.
   final ValueWidgetBuilder<T> builder;
+
+  /// Determines whether the [StateNotifierBuilder] should rebuild with the
+  /// current state of the [StateNotifier].
+  ///
+  /// [StateNotifierBuilder] will always rebuild when the [buildWhen] is null.
+  final BuildCondition<T> buildWhen;
 
   /// The listened [StateNotifier].
   ///
@@ -79,7 +88,9 @@ class _StateNotifierBuilderState<T> extends State<StateNotifierBuilder<T>> {
   }
 
   void _listener(T value) {
-    setState(() => state = value);
+    if (widget.buildWhen?.call(value) ?? true) {
+      setState(() => state = value);
+    }
   }
 
   @override

--- a/packages/flutter_state_notifier/test/state_notifier_builder_test.dart
+++ b/packages/flutter_state_notifier/test/state_notifier_builder_test.dart
@@ -29,6 +29,37 @@ void main() {
 
     expect(find.text('1'), findsOneWidget);
   });
+  testWidgets('rebuilds only when build condition is true', (tester) async {
+    final notifier = TestNotifier(0);
+    final child = Container();
+
+    await tester.pumpWidget(
+      StateNotifierBuilder<int>(
+        stateNotifier: notifier,
+        buildWhen: (state) => state % 2 == 0,
+        builder: (context, value, c) {
+          assert(context != null, '');
+          assert(child == c, '');
+          return Text('$value', textDirection: TextDirection.ltr);
+        },
+        child: child,
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+
+    notifier.increment();
+
+    await tester.pump();
+
+    expect(find.text('1'), findsNothing);
+
+    notifier.increment();
+
+    await tester.pump();
+
+    expect(find.text('2'), findsOneWidget);
+  });
   testWidgets('disposes sub', (tester) async {
     final notifier = TestNotifier(0);
 


### PR DESCRIPTION
Added a `buildWhen` callback to determine a `StateNotifierBuilder` should rebuild or not. By default, the `StateNotifierBuilder` it will always rebuild.

A simple example would be if you have a counter `StateNotifier` and you want to rebuild the widget only when the number is even, the code for that will be like this:
```dart
StateNotifierBuilder<int>(
    stateNotifier: notifier,
    buildWhen: (state) => state % 2 == 0,
    builder: (context, value, c) {
      return Text('$value', textDirection: TextDirection.ltr);
    },
    child: child,
)
```