### PR TITLE
updateShouldNotify checking behavior fix #58

### DIFF
--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -203,7 +203,7 @@ Consider checking `mounted`.
     T old,
     T current,
   ) =>
-      !identical(_state, current);
+      !identical(old, current);
 
   @protected
   set state(T value) {

--- a/packages/state_notifier/test/update_shoud_notifiy_test.dart
+++ b/packages/state_notifier/test/update_shoud_notifiy_test.dart
@@ -53,7 +53,7 @@ void main() {
   );
 
   test(
-    'update should notify receive to different refs',
+    'update should notify receive two different refs',
     () {
       // will notify if not identical
       final notifier = FakeTestNotifier();

--- a/packages/state_notifier/test/update_shoud_notifiy_test.dart
+++ b/packages/state_notifier/test/update_shoud_notifiy_test.dart
@@ -57,18 +57,17 @@ void main() {
     () {
       // will notify if not identical
       final notifier = FakeTestNotifier();
-      var callCount = 0;
-      notifier.addListener((state) {
-        // this should be called
-        callCount++;
-      });
+      final listener = Listener();
+
+      notifier.addListener(listener);
+
+      verify(listener(0));
+      verifyNoMoreInteractions(listener);
+
       notifier.increment();
-      expect(
-        callCount,
-        2,
-        reason:
-            'updateShouldNotify receive to different parameters with two different reference in memory',
-      );
+
+      verify(listener(1));
+      verifyNoMoreInteractions(listener);
     },
   );
 }

--- a/packages/state_notifier/test/update_shoud_notifiy_test.dart
+++ b/packages/state_notifier/test/update_shoud_notifiy_test.dart
@@ -23,6 +23,12 @@ class TestNotifier extends StateNotifier<int> with Mock {
   }
 }
 
+class FakeTestNotifier extends StateNotifier<int> {
+  FakeTestNotifier() : super(0);
+
+  void increment() => state++;
+}
+
 void main() {
   test(
     'it updates and does not notify when updateShouldNotify return false',
@@ -43,6 +49,26 @@ void main() {
 
       verifyNoMoreInteractions(listener);
       expect(notifier.debugState, 0);
+    },
+  );
+
+  test(
+    'update should notify receive to different refs',
+    () {
+      // will notify if not identical
+      final notifier = FakeTestNotifier();
+      var callCount = 0;
+      notifier.addListener((state) {
+        // this should be called
+        callCount++;
+      });
+      notifier.increment();
+      expect(
+        callCount,
+        2,
+        reason:
+            'updateShouldNotify receive to different parameters with two different reference in memory',
+      );
     },
   );
 }


### PR DESCRIPTION
this PR solves #58
thanks to @klondikedragon who made it clear where the bug was 
i made a small change and added one test to make sure it wont happened again

now `updateShouldNotify` compares between 
`old` and `current` states 

