### PR TITLE
expose state_notifier

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -3,7 +3,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
     - always_specify_types
     - always_use_package_imports
     - annotate_overrides
@@ -103,7 +102,6 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
-    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each

--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -28,7 +28,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_returning_this
     - avoid_setters_without_getters

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -14,7 +14,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
     - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters
     - await_only_futures
@@ -50,7 +49,6 @@ linter:
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
@@ -93,12 +91,6 @@ linter:
     # pedantic: disabled
     # http://dart-lang.github.io/linter/lints/always_declare_return_types.html
     # - always_put_required_named_parameters_first
-
-    # All non nullable named parameters should be and annotated with @required.
-    # This allows API consumers to get warnings via lint rather than a crash a runtime.
-    # Might become obsolete with Non-Nullable types
-    # http://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html
-    - always_require_non_null_named_parameters
 
     # Since dart 2.0 dart is a sound language, specifying types is not required anymore.
     # `var foo = 10;` is enough information for the compiler to make foo a int.
@@ -183,12 +175,6 @@ linter:
     # Not recommended to break dartdoc but besides that there is no reason to continue with bad naming
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
-
-    # Especially with Non-Nullable types on the horizon, `int?` is fine.
-    # There are plenty of valid reasons to return null.
-    # pedantic: disabled
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null.html
-    # - avoid_returning_null
 
     # Don't use `Future?`, therefore never return null instead of a Future.
     # Will become obsolete one Non-Nullable types land

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -176,11 +176,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
 
-    # Don't use `Future?`, therefore never return null instead of a Future.
-    # Will become obsolete one Non-Nullable types land
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_future.html
-    - avoid_returning_null_for_future
-
     # Use empty returns, don't show off with you knowledge about dart internals.
     # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_void.html
     - avoid_returning_null_for_void

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,7 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({super.begin, super.end});
+  MyStateTween({MyState? begin, MyState? end}) : super(begin: begin, end: end);
 
   @override
   MyState lerp(double t) {
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
+  const MyHomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,11 +41,11 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({MyState begin, MyState end}) : super(begin: begin, end: end);
+  MyStateTween({super.begin, super.end});
 
   @override
   MyState lerp(double t) {
-    final countTween = IntTween(begin: begin.count, end: end.count);
+    final countTween = IntTween(begin: begin?.count, end: end?.count);
     // Tween the count
     return MyState(
       countTween.lerp(t),
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_state_notifier/CHANGELOG.md
+++ b/packages/flutter_state_notifier/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+The package now re-exports `package:state_notifier`
+
 ## 0.7.1
 
 - Update dependencies

--- a/packages/flutter_state_notifier/example/analysis_options.yaml
+++ b/packages/flutter_state_notifier/example/analysis_options.yaml
@@ -175,11 +175,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
 
-    # Don't use `Future?`, therefore never return null instead of a Future.
-    # Will become obsolete one Non-Nullable types land
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_future.html
-    - avoid_returning_null_for_future
-
     # Use empty returns, don't show off with you knowledge about dart internals.
     # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_void.html
     - avoid_returning_null_for_void

--- a/packages/flutter_state_notifier/example/analysis_options.yaml
+++ b/packages/flutter_state_notifier/example/analysis_options.yaml
@@ -14,7 +14,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
     - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters
     - await_only_futures
@@ -50,7 +49,6 @@ linter:
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
@@ -76,7 +74,6 @@ linter:
     - use_rethrow_when_possible
     - valid_regexps
 
-
     # Prevents accidental return type changes which results in a breaking API change.
     # Enforcing return type makes API changes visible in a diff
     # pedantic: enabled
@@ -93,12 +90,6 @@ linter:
     # pedantic: disabled
     # http://dart-lang.github.io/linter/lints/always_declare_return_types.html
     # - always_put_required_named_parameters_first
-
-    # All non nullable named parameters should be and annotated with @required.
-    # This allows API consumers to get warnings via lint rather than a crash a runtime.
-    # Might become obsolete with Non-Nullable types
-    # http://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html
-    - always_require_non_null_named_parameters
 
     # Since dart 2.0 dart is a sound language, specifying types is not required anymore.
     # `var foo = 10;` is enough information for the compiler to make foo a int.
@@ -183,12 +174,6 @@ linter:
     # Not recommended to break dartdoc but besides that there is no reason to continue with bad naming
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
-
-    # Especially with Non-Nullable types on the horizon, `int?` is fine.
-    # There are plenty of valid reasons to return null.
-    # pedantic: disabled
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null.html
-    # - avoid_returning_null
 
     # Don't use `Future?`, therefore never return null instead of a Future.
     # Will become obsolete one Non-Nullable types land

--- a/packages/flutter_state_notifier/example/lib/main.dart
+++ b/packages/flutter_state_notifier/example/lib/main.dart
@@ -41,7 +41,7 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({super.begin, super.end});
+  MyStateTween({MyState? begin, MyState? end}) : super(begin: begin, end: end);
 
   @override
   MyState lerp(double t) {
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
+  const MyHomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_state_notifier/example/lib/main.dart
+++ b/packages/flutter_state_notifier/example/lib/main.dart
@@ -41,11 +41,11 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({MyState begin, MyState end}) : super(begin: begin, end: end);
+  MyStateTween({super.begin, super.end});
 
   @override
   MyState lerp(double t) {
-    final countTween = IntTween(begin: begin.count, end: end.count);
+    final countTween = IntTween(begin: begin?.count, end: end?.count);
     // Tween the count
     return MyState(
       countTween.lerp(t),
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_state_notifier/example/pubspec.yaml
+++ b/packages/flutter_state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_state_notifier/example/pubspec.yaml
+++ b/packages/flutter_state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_state_notifier/example/pubspec.yaml
+++ b/packages/flutter_state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
+++ b/packages/flutter_state_notifier/lib/flutter_state_notifier.dart
@@ -7,6 +7,8 @@ import 'package:provider/provider.dart' hide Locator;
 import 'package:provider/single_child_widget.dart';
 import 'package:state_notifier/state_notifier.dart';
 
+export 'package:state_notifier/state_notifier.dart' hide Listener, Locator;
+
 /// {@template flutter_state_notifier.state_notifier_builder}
 /// Listens to a [StateNotifier] and use it builds a widget tree based on the
 /// latest value.

--- a/packages/flutter_state_notifier/pubspec.yaml
+++ b/packages/flutter_state_notifier/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_state_notifier
 description: Flutter bindings for state_notifier, such as StateNotifierProvider and StateNotifierBuilder
-version: 0.7.1
+version: 0.7.3
 homepage: https://github.com/rrousselGit/state_notifier
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   meta: ^1.1.8
   provider: ^6.0.0
-  state_notifier: ^0.7.1
+  state_notifier: 0.7.2+1
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_state_notifier/test/state_notifier_provider_test.dart
+++ b/packages/flutter_state_notifier/test/state_notifier_provider_test.dart
@@ -77,6 +77,7 @@ void main() {
     await tester.pumpWidget(
       StateNotifierProvider<TestNotifier, int>(
         create: (_) => notifier,
+        // ignore: prefer_const_constructors
         child: Column(
           textDirection: TextDirection.ltr,
           children: const <Widget>[
@@ -102,6 +103,7 @@ void main() {
     await tester.pumpWidget(
       StateNotifierProvider<TestNotifier, int>(
         create: (_) => notifier,
+        // ignore: prefer_const_constructors
         child: Column(
           textDirection: TextDirection.ltr,
           children: const <Widget>[
@@ -266,6 +268,7 @@ void main() {
       StateNotifierProvider<TestNotifier, int>(
         key: key,
         create: (_) => notifier,
+        // ignore: prefer_const_constructors
         child: Column(
           textDirection: TextDirection.ltr,
           children: const <Widget>[
@@ -290,6 +293,7 @@ void main() {
       StateNotifierProvider<TestNotifier, int>.value(
         key: key,
         value: notifier,
+        // ignore: prefer_const_constructors
         child: Column(
           textDirection: TextDirection.ltr,
           children: const <Widget>[

--- a/packages/flutter_state_notifier/test/state_notifier_provider_test.dart
+++ b/packages/flutter_state_notifier/test/state_notifier_provider_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:state_notifier/state_notifier.dart';
 
 import 'common.dart';
 

--- a/packages/state_notifier/example/analysis_options.yaml
+++ b/packages/state_notifier/example/analysis_options.yaml
@@ -175,11 +175,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
 
-    # Don't use `Future?`, therefore never return null instead of a Future.
-    # Will become obsolete one Non-Nullable types land
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_future.html
-    - avoid_returning_null_for_future
-
     # Use empty returns, don't show off with you knowledge about dart internals.
     # https://dart-lang.github.io/linter/lints/avoid_returning_null_for_void.html
     - avoid_returning_null_for_void

--- a/packages/state_notifier/example/analysis_options.yaml
+++ b/packages/state_notifier/example/analysis_options.yaml
@@ -14,7 +14,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
     - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters
     - await_only_futures
@@ -50,7 +49,6 @@ linter:
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
@@ -76,7 +74,6 @@ linter:
     - use_rethrow_when_possible
     - valid_regexps
 
-
     # Prevents accidental return type changes which results in a breaking API change.
     # Enforcing return type makes API changes visible in a diff
     # pedantic: enabled
@@ -93,12 +90,6 @@ linter:
     # pedantic: disabled
     # http://dart-lang.github.io/linter/lints/always_declare_return_types.html
     # - always_put_required_named_parameters_first
-
-    # All non nullable named parameters should be and annotated with @required.
-    # This allows API consumers to get warnings via lint rather than a crash a runtime.
-    # Might become obsolete with Non-Nullable types
-    # http://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html
-    - always_require_non_null_named_parameters
 
     # Since dart 2.0 dart is a sound language, specifying types is not required anymore.
     # `var foo = 10;` is enough information for the compiler to make foo a int.
@@ -183,12 +174,6 @@ linter:
     # Not recommended to break dartdoc but besides that there is no reason to continue with bad naming
     # https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html
     # - avoid_renaming_method_parameters
-
-    # Especially with Non-Nullable types on the horizon, `int?` is fine.
-    # There are plenty of valid reasons to return null.
-    # pedantic: disabled
-    # https://dart-lang.github.io/linter/lints/avoid_returning_null.html
-    # - avoid_returning_null
 
     # Don't use `Future?`, therefore never return null instead of a Future.
     # Will become obsolete one Non-Nullable types land

--- a/packages/state_notifier/example/lib/main.dart
+++ b/packages/state_notifier/example/lib/main.dart
@@ -41,7 +41,7 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({super.begin, super.end});
+  MyStateTween({MyState? begin, MyState? end}) : super(begin: begin, end: end);
 
   @override
   MyState lerp(double t) {
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
+  const MyHomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/state_notifier/example/lib/main.dart
+++ b/packages/state_notifier/example/lib/main.dart
@@ -41,11 +41,11 @@ void main() {
 ///
 /// This will apply an [IntTween] on [MyState.count].
 class MyStateTween extends Tween<MyState> {
-  MyStateTween({MyState begin, MyState end}) : super(begin: begin, end: end);
+  MyStateTween({super.begin, super.end});
 
   @override
   MyState lerp(double t) {
-    final countTween = IntTween(begin: begin.count, end: end.count);
+    final countTween = IntTween(begin: begin?.count, end: end?.count);
     // Tween the count
     return MyState(
       countTween.lerp(t),
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/state_notifier/example/pubspec.yaml
+++ b/packages/state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/state_notifier/example/pubspec.yaml
+++ b/packages/state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/state_notifier/example/pubspec.yaml
+++ b/packages/state_notifier/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
It would be better that exposing state_notifier in flutter_state_notifier like [Riverpod does](https://github.com/rrousselGit/riverpod/blob/riverpod-v2.1.3/packages/riverpod/lib/riverpod.dart#L1).