### PR TITLE
Add the ability to set state in debug

### DIFF
--- a/example/test/my_state_notifier_test.dart
+++ b/example/test/my_state_notifier_test.dart
@@ -7,11 +7,11 @@ void main() {
     final logger = LoggerMock();
     final myNotifier = MyStateNotifier()..debugMockDependency<Logger>(logger);
 
-    expect(myNotifier.debugState.count, 0);
+    expect(myNotifier.state.count, 0);
 
     myNotifier.increment();
 
-    expect(myNotifier.debugState.count, 1000);
+    expect(myNotifier.state.count, 1000);
     verify(logger.countChanged(1000)).called(1);
     verifyNoMoreInteractions(logger);
   });

--- a/packages/flutter_state_notifier/CHANGELOG.md
+++ b/packages/flutter_state_notifier/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased minor
+
+- `state` is now accessible in tests without a warning.
+- Deprecated `debugState`. Use `state` instead.
+
 ## 0.7.3
 
 The package now re-exports `package:state_notifier`

--- a/packages/flutter_state_notifier/example/test/my_state_notifier_test.dart
+++ b/packages/flutter_state_notifier/example/test/my_state_notifier_test.dart
@@ -7,11 +7,11 @@ void main() {
     final logger = LoggerMock();
     final myNotifier = MyStateNotifier()..debugMockDependency<Logger>(logger);
 
-    expect(myNotifier.debugState.count, 0);
+    expect(myNotifier.state.count, 0);
 
     myNotifier.increment();
 
-    expect(myNotifier.debugState.count, 1000);
+    expect(myNotifier.state.count, 1000);
     verify(logger.countChanged(1000)).called(1);
     verifyNoMoreInteractions(logger);
   });

--- a/packages/state_notifier/CHANGELOG.md
+++ b/packages/state_notifier/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased minor
+
+- `state` is now accessible in tests without a warning.
+- Deprecated `debugState`. Use `state` instead.
+
 ## 0.7.2+1
 
 - Fixed an issue with `updateShouldNotify` naturally always returning `false`.

--- a/packages/state_notifier/example/test/my_state_notifier_test.dart
+++ b/packages/state_notifier/example/test/my_state_notifier_test.dart
@@ -7,11 +7,11 @@ void main() {
     final logger = LoggerMock();
     final myNotifier = MyStateNotifier()..debugMockDependency<Logger>(logger);
 
-    expect(myNotifier.debugState.count, 0);
+    expect(myNotifier.state.count, 0);
 
     myNotifier.increment();
 
-    expect(myNotifier.debugState.count, 1000);
+    expect(myNotifier.state.count, 1000);
     verify(logger.countChanged(1000)).called(1);
     verifyNoMoreInteractions(logger);
   });

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -245,6 +245,7 @@ Consider checking `mounted`.
   /// Will not work in release mode.
   ///
   /// This is useful for tests.
+  @visibleForTesting
   T get debugState {
     late T result;
     assert(() {
@@ -260,6 +261,7 @@ Consider checking `mounted`.
   /// Will not work in release mode.
   ///
   /// This is useful for tests to provide seed state.
+  @visibleForTesting
   set debugState(T value) {
     assert(() {
       _state = value;

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -254,6 +254,19 @@ Consider checking `mounted`.
     return result;
   }
 
+  /// A development-only way to set [state] outside of [StateNotifier].
+  ///
+  /// The only difference with [state] is that [debugState] is not "protected".\
+  /// Will not work in release mode.
+  ///
+  /// This is useful for tests to provide seed state.
+  set debugState(T value) {
+    assert(() {
+      _state = value;
+      return true;
+    }(), '');
+  }
+
   /// If a listener has been added using [addListener] and hasn't been removed yet.
   bool get hasListeners {
     assert(_debugIsMounted(), '');

--- a/packages/state_notifier/lib/state_notifier.dart
+++ b/packages/state_notifier/lib/state_notifier.dart
@@ -192,6 +192,7 @@ Consider checking `mounted`.
   ///
   /// Updating the state will throw if at least one listener throws.
   @protected
+  @visibleForTesting
   T get state {
     assert(_debugIsMounted(), '');
     return _state;
@@ -206,6 +207,7 @@ Consider checking `mounted`.
       !identical(old, current);
 
   @protected
+  @visibleForTesting
   set state(T value) {
     assert(_debugIsMounted(), '');
     final previousState = _state;
@@ -245,7 +247,7 @@ Consider checking `mounted`.
   /// Will not work in release mode.
   ///
   /// This is useful for tests.
-  @visibleForTesting
+  @Deprecated('Use state instead')
   T get debugState {
     late T result;
     assert(() {
@@ -253,20 +255,6 @@ Consider checking `mounted`.
       return true;
     }(), '');
     return result;
-  }
-
-  /// A development-only way to set [state] outside of [StateNotifier].
-  ///
-  /// The only difference with [state] is that [debugState] is not "protected".\
-  /// Will not work in release mode.
-  ///
-  /// This is useful for tests to provide seed state.
-  @visibleForTesting
-  set debugState(T value) {
-    assert(() {
-      _state = value;
-      return true;
-    }(), '');
   }
 
   /// If a listener has been added using [addListener] and hasn't been removed yet.

--- a/packages/state_notifier/test/state_notifier_test.dart
+++ b/packages/state_notifier/test/state_notifier_test.dart
@@ -30,32 +30,32 @@ Matcher throwsStateNotifierListenerError({
 
 void main() {
   test('initialize state with default value', () {
-    expect(TestNotifier(0).currentState, 0);
-    expect(TestNotifier(42).currentState, 42);
-    expect(TestNotifier(0).debugState, 0);
-    expect(TestNotifier(42).debugState, 42);
+    expect(TestNotifier(0).state, 0);
+    expect(TestNotifier(42).state, 42);
   });
 
   test('setter modifies the value', () {
     final notifier = TestNotifier(0);
 
-    expect(notifier.currentState, 0);
-    expect(notifier.debugState, 0);
+    expect(notifier.state, 0);
 
     notifier.increment();
-    expect(notifier.currentState, 1);
-    expect(notifier.debugState, 1);
+    expect(notifier.state, 1);
 
     notifier.increment();
-    expect(notifier.currentState, 2);
-    expect(notifier.debugState, 2);
+    expect(notifier.state, 2);
   });
 
-  test('debugState modifies the value', () {
+  test('can set state', () {
     final notifier = TestNotifier(0);
-    notifier.debugState = 1;
-    expect(notifier.currentState, 1);
-    expect(notifier.debugState, 1);
+    expectLater(notifier.stream, emitsInOrder([1, 2]));
+    notifier.state = 1;
+    expect(notifier.state, 1);
+    notifier.state = 2;
+    expect(notifier.state, 2);
+    notifier.state = 2;
+    expect(notifier.state, 2);
+    notifier.dispose();
   });
 
   test(
@@ -206,7 +206,7 @@ void main() {
 
     notifier.dispose();
 
-    expect(() => notifier.currentState, throwsStateError);
+    expect(() => notifier.state, throwsStateError);
     expect(notifier.increment, throwsStateError);
     expect(() => notifier.hasListeners, throwsStateError);
     expect(() => notifier.read, throwsStateError);
@@ -461,8 +461,6 @@ void main() {
 
 class TestNotifier extends StateNotifier<int> with LocatorMixin {
   TestNotifier(int state) : super(state);
-
-  int get currentState => state;
 
   void increment() => state++;
 

--- a/packages/state_notifier/test/state_notifier_test.dart
+++ b/packages/state_notifier/test/state_notifier_test.dart
@@ -51,6 +51,13 @@ void main() {
     expect(notifier.debugState, 2);
   });
 
+  test('debugState modifies the value', () {
+    final notifier = TestNotifier(0);
+    notifier.debugState = 1;
+    expect(notifier.currentState, 1);
+    expect(notifier.debugState, 1);
+  });
+
   test(
       'listener called immediately on addition + synchronously on value change',
       () {

--- a/packages/state_notifier/test/update_should_notify_test.dart
+++ b/packages/state_notifier/test/update_should_notify_test.dart
@@ -48,7 +48,7 @@ void main() {
       notifier.decrement();
 
       verifyNoMoreInteractions(listener);
-      expect(notifier.debugState, 0);
+      expect(notifier.state, 0);
     },
   );
 


### PR DESCRIPTION
This PR adds `debugState` setter which changes `state` when in debug mode. This is essential when testing a `StateNotifier` and you want to provide a seed state. It becomes much easier to simulate different scenarios.

Also, isn't it better to annotate both `debugState` getter and setter with `@visibleForTesting`?